### PR TITLE
[feat] : tree-sitter-smallbasic grammar.js

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,5 +1,5 @@
 module.exports = grammar({
-    name: 'nodejs',
+    name: "nodejs",
   
     rules: {
       // TODO: add the actual grammar rules
@@ -11,23 +11,100 @@ module.exports = grammar({
   
       // junk: $ => /[^%@\s\n\t][^%@]*/,
   
-      // comment: $ => token(seq('%', /.*/)),
-  
+      // comment: $ => token(seq("%", /.*/)),
+
       // _command_or_entry: $ => seq("@", /[a-zA-Z]+/)
 
+
+      // Non-Terminals
       Start: $ => $.Prog,
 
       Prog: $ => $.MoreThanOneStmt,
 
       Stmt: $ => choice(
         $.ExprStatement,
-        seq( /[Ww][Hh][Ii][Ll][Ee]/,  $.Expr, $.CRStmtCRs, /[Ee][Nn][Dd][Ww][Hh][Ii][Ll][Ee]/  ),
-        seq($.ID, ':'),
+        seq( /[Ww][Hh][Ii][Ll][Ee]/,  $.Expr, $.CRStmtCRs, /[Ee][Nn][Dd][Ww][Hh][Ii][Ll][Ee]/),
+        seq($.ID, ":"),
         seq(/[Gg][Oo][Tt][Oo]/, $.ID),
-        seq(/[Ff][Oo][Rr]/, $.ID, '=', $.Expr, /[Tt][Oo]/, $.Expr, $.OptStep, $.CRStmtCRs, /[Ee][Nn][Dd][Ff][Oo][Rr]/),
+        seq(/[Ff][Oo][Rr]/, $.ID, "=", $.Expr, /[Tt][Oo]/, $.Expr, $.OptStep, $.CRStmtCRs, /[Ee][Nn][Dd][Ff][Oo][Rr]/),
         seq(/[Ss][Uu][Bb]/, $.ID, $.CRStmtCRs, /[Ee][Nn][Dd][Ss][Uu][Bb]/),
         seq(/[Ii][Ff]/, $.Expr, /[Tt][Hh][Ee][Nn]/, $.CRStmtCRs, $.MoreThanZeroElseIf),
-        seq()
+        // *공백이 오는 경우 표현(확인 후 작성 필요)
+      ),
+
+      MoreThanZeroElseIf: $ => choice(
+        $.OptionalElse,
+        seq(/[Ee][Ll][Ss][Ee][Ii][Ff]/, $.Expr, /[Tt][Hh][Ee][Nn]/, $.CRStmtCRs, $.MoreThanZeroElseIf),
+      ),
+      
+      OptionalElse: $ => choice(
+        /[Ee][Nn][Dd][Ii][Ff]/,
+        seq(/[Ee][Ll][Ss][Ee]/, $.CRStmtCRs, /[Ee][Nn][Dd][Ii][Ff]/)
+      ),
+
+      ExprStatement: $ => choice(
+        seq($.ID, "=", $.Expr),
+        seq($.ID, ".", $.ID, "=", $.Expr),
+        seq($.ID, ".", $.ID, "(", $.Exprs, ")"),
+        seq($.ID, "(", ")"),
+        seq($.ID, $.Idxs, "=", $.Expr),
+      ),
+      
+      // CRStmtCRS -> CR TheRest
+      // CR은 다음 2가지 "\r\n" or "\n"
+      // "\r\n" or "\n" 정규표현식 : /\r\n|\n/ 캐리지리턴이 있거나 없거나 둘 중 하나
+      CRStmtCRs: $ => seq(choice(/\r\n|\n/) ,$.TheRest),
+
+      TheRest: $ => choice(
+        // *공백이 오는 경우 표현(확인 후 작성 필요)
+        seq($.Stmt, choice(/\r\n|\n/), $.TheRest),
+      ),
+
+      MoreThanOneStmt: $ => choice(
+        $.Stmt,
+        seq($.Stmt, choice(/\r\n|\n/), $.MoreThanOneStmt),
+      ),
+
+      OptStep: $ => choice(
+        // *공백이 오는 경우 표현(확인 후 작성 필요),
+        seq(/[Ss][Tt][Ee][Pp]/, $.Expr),
+      ),
+
+      Expr: $ => $.CondExpr,
+
+      Exprs: $ => choice(
+        // *공백이 오는 경우 표현(확인 후 작성 필요),
+        $.MoreThanOneExpr,
+      ),
+
+      MoreThanOneExpr: $ => choice(
+        $.Expr,
+        seq($.Expr, $.MoreThanOneExpr),
+      ),
+
+      CondExpr: $ => $.OrExpr,
+
+      OrExpr: $ => choice(
+        seq($.OrExpr, /[Oo][Rr]/, $.AndExpr),
+      ),
+
+      AndExpr: $ => choice(
+        seq($.AndExpr, /[Aa][Nn][Dd]/, $.EqNeqExpr),
+      ),
+      
+      // <>의 뜻은 NotEqual(!=와 같음)
+      EqNeqExpr: $ => choice(
+        seq($.EqNeqExpr, "=", $.CompExpr),
+        seq($.EqNeqExpr, "<>", $.CompExpr),
+        $.CompExpr,
+      ),
+
+      CompExpr: $ => choice(
+        seq($.CompExpr, "<", $.AdditiveExpr),
+        seq($.CompExpr, "<=", $.AdditiveExpr),
+        seq($.CompExpr, ">", $.AdditiveExpr),
+        seq($.CompExpr, ">=", $.AdditiveExpr),
+        $.AdditiveExpr,
       ),
 
       // Terminals


### PR DESCRIPTION
> **작업 사항**

- `sbparser` 69 Lines - `CompExpr` 심볼까지 `rules` 정의
- 문자열을 표현할 때 `''`가 아닌 `""`가 쓰이도록 수정
- `sbparser` 상에서 공백으로 나오는 부분을 일단 다음과 같이 주석 처리 해놓음 
  ```js
  OptStep: $ => choice(
  // *공백이 오는 경우 표현(확인 후 작성 필요)
  ```
- `CR` 심볼의 경우 `/\r\n|\n/` 표현식으로 정의

> **2가지 걸리는 점**

**1. 현재 프로젝트 초기에 `node.js` 명칭으로 작성하여 몇몇 파일 세부 내용이 `node.js` 키워드가 들어가 있는 것(어떤 영향을 끼치는지 현재 상황에서는 정확히 파악하지 못함)**
```
좌측 : tree-sitter-smallbasic(현재 프로젝트)
우측 : tree-sitter-python
```
  ![image](https://github.com/cosmos-1885/tree-sitter-smallbasic/assets/67001905/b6aa3e52-a34d-4700-ae27-36da4583001a)
  ![image](https://github.com/cosmos-1885/tree-sitter-smallbasic/assets/67001905/7c8ec19f-e68d-40d3-822e-6dea45492dab)
  ![image](https://github.com/cosmos-1885/tree-sitter-smallbasic/assets/67001905/d1fb1a39-6549-433d-8204-3ae0575b5b50)
  ![image](https://github.com/cosmos-1885/tree-sitter-smallbasic/assets/67001905/4aaab309-1f04-46a3-ad9d-9b3b7ca42341)

**2. `haskell` 문법에서의 표기법을 `grammar.js`로 옮겨오는 과정에서의 문법 오류 발생가능성**
```
이 부분은 전체적인 큰 틀을 짜고나서 하나하나 세밀히 살펴보는 과정이 필요할 것으로 보입니다!
```